### PR TITLE
Bugfix: accession numbers parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Datasets
+datasets/
+
+# Logs
+logs/
+
+# Config
+config.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -157,4 +166,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The purpose of EDGAR-CRAWLER is to speed up research and experiments that rely o
       - `--cik_tickers`: list or path of file containing CIKs or Tickers. e.g. `[789019, "1018724", "AAPL", "TWTR"]` <br>
         In case of file, provide each CIK or Ticker in a different line.  <br>
       If this argument is not provided, then the toolkit will download annual reports for all the U.S. publicly traded companies.
-      - `--user_agent`: the User-agent that will be declared to SEC EDGAR.
+      - `--user_agent`: the User-agent (name/email) that will be declared to SEC EDGAR.
       - `--raw_filings_folder`: the name of the folder where downloaded filings will be stored.<br> Default value is `'RAW_FILINGS'`.
       - `--indices_folder`: the name of the folder where EDGAR TSV files will be stored. These are used to locate the annual reports. Default value is `'INDICES'`.
       - `--filings_metadata_file`: CSV filename to save metadata from the reports.

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ The purpose of EDGAR-CRAWLER is to speed up research and experiments that rely o
 - Install dependencies via `pip install -r requirements.txt`
 
 ## Usage
-- Before running any script, you can edit the `config.json` file.
+- Before running any script, you should edit the `config.json` file.
   - Arguments for `edgar_crawler.py`, the module to download financial reports:
-      - `--start_year XXXX`: the year range to start from
-      - `--end_year YYYY`: the year range to end to
+      - `--start_year XXXX`: the year range to start from (default is 2021)
+      - `--end_year YYYY`: the year range to end to (default is 2021)
       - `--quarters`: the quarters that you want to download filings from (List).<br> Default value is: `[1, 2, 3, 4]`.
       - `--filing_types`: list of filing types to download.<br> Default value is: `['10-K', '10-K405', '10-KT']`.
       - `--cik_tickers`: list or path of file containing CIKs or Tickers. e.g. `[789019, "1018724", "AAPL", "TWTR"]` <br>

--- a/edgar_crawler.py
+++ b/edgar_crawler.py
@@ -480,7 +480,7 @@ def crawl(
 
 			if link_to_download is not None:
 				filing_type = re.sub(r"[\-/\\]", '', filing_type)
-				accession_num = series['complete_text_file_link'].split(os.sep)[-1].split('.')[0]
+				accession_num = os.path.splitext(os.path.basename(series['complete_text_file_link']))[0]
 				filename = f"{str(series['CIK'])}_{filing_type}_{period_of_report[:4]}_{accession_num}.{file_extension}"
 
 				# Download the file


### PR DESCRIPTION
It seems that EDGAR now incorporates the absolute URLs in the complete text file links in the .tsv indexes, instead of the relative URLs, as when we developed the toolkit.

That causes line 483 on edgar_crawler.py to parse the string incorrectly and try to write to an invalid filename like `https://www.txt/'`). This would crash, as mentioned in [issue #4](https://github.com/nlpaueb/edgar-crawler/issues/4).

I replaced this line using 2 os.path functions.

In the same PR, I also introduce some minor changes:
- Update in README
- Add .gitignore
