### PR TITLE
Fix for partial item extraction

### DIFF
--- a/extract_items.py
+++ b/extract_items.py
@@ -486,7 +486,7 @@ class ExtractItems:
 
                 possible = list(
                     re.finditer(
-                        rf"\n[^\S\r\n]*ITEM\s+{item_index}[.*~\-:\s].+?([^\S\r\n]*ITEM\s+{str(next_item_index)}[.*~\-:\s])",
+                        rf"\n[^\S\r\n]*ITEM\s+{item_index}[.*~\-:\s].+?(\n[^\S\r\n]*ITEM\s+{str(next_item_index)}[.*~\-:\s])",
                         text[offset:],
                         flags=regex_flags,
                     )


### PR DESCRIPTION
Fix item extraction behavior - sometimes only parts of an item were extracted if the next item was mentioned in the current item content. This should fix #20 