### PR TITLE
Allow downloading non periodic filings / non financial reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# OS X
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ pip install -r requirements.txt # Install requirements for edgar-crawler
       - `raw_filings_folder`: the name of the folder where downloaded filings will be stored.<br> Default value is `'RAW_FILINGS'`.
       - `indices_folder`: the name of the folder where EDGAR TSV files will be stored. These are used to locate the annual reports. Default value is `'INDICES'`.
       - `filings_metadata_file`: CSV filename to save metadata from the reports.
+      - `non_periodic_filing_types`: filing types that do not have period of report (e.g. 144).
       - `skip_present_indices`: Whether to skip already downloaded EDGAR indices or download them nonetheless.<br> Default value is `True`.
   - Arguments for `extract_items.py`, the module to clean and extract textual data from already-downloaded reports:
     - `raw_filings_folder`: the name of the folder where the downloaded documents are stored.<br> Default value s `'RAW_FILINGS'`.

--- a/config.json
+++ b/config.json
@@ -9,6 +9,7 @@
 		"raw_filings_folder": "RAW_FILINGS",
 		"indices_folder": "INDICES",
 		"filings_metadata_file": "FILINGS_METADATA.csv",
+		"non_periodic_filing_types": ["144"],
 		"skip_present_indices": true
 	},
 	"extract_items": {


### PR DESCRIPTION
# Description
This add support to download non financial reports which do not have period of report field.

## Consideration
- The full list is not added as the [list of submission types](https://www.sec.gov/info/edgar/forms/edgform.pdf) is huge.
- I thought about hard coding the list of `non_periodic_filing_types` list to `item_lists.py` but this way, there is no need to create a pull request to support other filings.

## Disclaimer
I am concerned that the repository is focused on financial reports, but it might be of interest to add support for other kind of filings, as many people (like I did), reached this repo looking to crawl any kind of edgar report.